### PR TITLE
Fix `errors!` format regression.

### DIFF
--- a/lib/reactive_record/active_record/reactive_record/base.rb
+++ b/lib/reactive_record/active_record/reactive_record/base.rb
@@ -297,7 +297,7 @@ module ReactiveRecord
       errors.clear && return unless hash
       hash.each do |attribute, messages|
         messages.each do |message|
-          errors.add(attribute, message: message)
+          errors.add(attribute, message)
         end
       end
     end


### PR DESCRIPTION
When I migrated to the Rails API compatible Errors implementation I made a mistake here causing a regression. Here's an example puts showing the incorrect data format. What comes from the server is correct, but what's recreated on the client here by this method is wrong (note the erroneous hash with `message:` key, that should be a string):

```
{"success"=>false, "saved_models"=>[[362644, "IndustriesPreference", {"id"=>37, "industry_id"=>2, "preference_id"=>2}, {"industries"=>["maximum 3 industries"]}]], "message"=>"undefined local variable or method `model' for ReactiveRecord::Base:Class\nDid you mean?  models", "models"=>[<IndustriesPreference:0x58894 (0x58892) [errors {"industries"=>[{"message"=>"maximum 3 industries"}]}] >]} 
```

It's not entirely clear from the Rails docs how `add` is supposed to work, most examples pass in a symbol corresponding to an i18n message, with an optional `message:` key for overriding the i18n lookup. But there are 2 reasons why that can't work: the i18n bit hasn't been ported, and Opal doesn't distinguish between symbols and strings. We send the message from the server anyway rather than the i18n key so it's a moot point. Just do it this way.